### PR TITLE
Revert "Catch a typo of raincloud plot tutorial" actions failing

### DIFF
--- a/raincloud_plot_tutorial.rmd
+++ b/raincloud_plot_tutorial.rmd
@@ -500,7 +500,7 @@ Isn’t the data itself is talking in this graph? I know the code is a little bi
 
 ## More Examples
 
-In this section, I organized codes from some of my previous work to provide you more examples! You can select one as a template to create your own! Typically, you can use raincloud plot if you have:
+n this section, I organized codes from some of my previous work to provide you more examples! You can select one as a template to create your own! Typically, you can use raincloud plot if you have:
 
 - 1 categorical variable, and 1 numerical variable (We already did that!)
 


### PR DESCRIPTION
Reverts jtr13/cc21fall2#183 I don't think this is the issue but github actions is failing due to dependencies not being set-up correctly - can't see that this changed anything but reverting as it was working 2 days ago!